### PR TITLE
handle null pointer returned from fil_aggregate (#116)

### DIFF
--- a/bls.go
+++ b/bls.go
@@ -61,7 +61,9 @@ func HashVerify(signature *Signature, messages []Message, publicKeys []PublicKey
 	return isValid > 0
 }
 
-// Aggregate aggregates signatures together into a new signature
+// Aggregate aggregates signatures together into a new signature. If the
+// provided signatures cannot be aggregated (due to invalid input or an
+// an operational error), Aggregate will return nil.
 func Aggregate(signatures []Signature) *Signature {
 	// prep data
 	flattenedSignatures := make([]byte, SignatureBytes*len(signatures))
@@ -70,6 +72,10 @@ func Aggregate(signatures []Signature) *Signature {
 	}
 
 	resp := generated.FilAggregate(string(flattenedSignatures), uint(len(flattenedSignatures)))
+	if resp == nil {
+		return nil
+	}
+
 	defer generated.FilDestroyAggregateResponse(resp)
 
 	resp.Deref()

--- a/bls_test.go
+++ b/bls_test.go
@@ -87,6 +87,19 @@ func BenchmarkBLSVerify(b *testing.B) {
 	}
 }
 
+func TestBlsAggregateErrors(t *testing.T) {
+	t.Run("no signatures", func(t *testing.T) {
+		var empty []Signature
+		out := Aggregate(empty)
+		require.Nil(t, out)
+	})
+
+	t.Run("nil signatures", func(t *testing.T) {
+		out := Aggregate(nil)
+		require.Nil(t, out)
+	})
+}
+
 func BenchmarkBLSVerifyBatch(b *testing.B) {
 	b.Run("10", benchmarkBLSVerifyBatchSize(10))
 	b.Run("50", benchmarkBLSVerifyBatchSize(50))


### PR DESCRIPTION
An error from fil_aggregate is encoded as a NUL byte. Unlike other FFI "Response" structs, there is no error code and message. As such, we need to check for the Go nil value before dereferencing the inner signature (which produced a nil-pointer exception today).